### PR TITLE
Fixed AppVeyor build issue: 'Core.AppConstants.BASE_URL.get' must dec…

### DIFF
--- a/c#/Mandoline.Api.Examples/Core/AppConstants.cs
+++ b/c#/Mandoline.Api.Examples/Core/AppConstants.cs
@@ -47,7 +47,7 @@ namespace Core
             }
         }
 
-        public static string BASE_URL { get; }
+        public static string BASE_URL { get; set; }
 
         // simple example selection: draws GDP and inflation data from the US, the UK, France, and Germany 
         public class SampleSelect : SelectionDto {


### PR DESCRIPTION
…lare a body because it is not marked abstract or extern