### PR TITLE
add missing forward slash

### DIFF
--- a/r/download_selection.r
+++ b/r/download_selection.r
@@ -50,7 +50,7 @@ download_selection_as_dataframe <- function(selection_id)
 download_raw_data <- function(selection_id)
 {
 	# select resource endpoint, in this case /download
-	endpoint <- '/download'
+	endpoint <- '/download/'
 	options <- '?includemetadata=true&page='
 
 	# set up and run the request


### PR DESCRIPTION
The http_request in the r script appears to fail due to a missing forward slash. Perhaps it's due to some other aspect of my setup, but adding a slash here seemed to fix it for me.